### PR TITLE
Cache settings

### DIFF
--- a/internal/commands/insult.go
+++ b/internal/commands/insult.go
@@ -3,11 +3,12 @@ package commands
 import (
 	"fmt"
 	"math/rand"
-	"time"
 	"strings"
+	"time"
 )
 
 func (bc BotCommand) Insult(event BotCommand) (response Response, err error) {
+	insults := event.settings.GetInsults()
 	response.Type = "post"
 	var index int
 
@@ -15,12 +16,12 @@ func (bc BotCommand) Insult(event BotCommand) (response Response, err error) {
 		response.Type = "post"
 		response.Message = "You must tell me who to insult"
 	}
-	arraySize := len(event.mm.Settings.Insults)
+	arraySize := len(insults)
 
 	rand := rand.New(rand.NewSource(time.Now().UnixNano()))
 	index = rand.Intn(arraySize)
-	response.Message = fmt.Sprintf(`%s`, event.mm.Settings.Insults[index])
-	response.Message = strings.Replace(response.Message, "{nick}", event.mm.Settings.Nick, -1)
+	response.Message = fmt.Sprintf(`%s`, insults[index])
+	response.Message = strings.Replace(response.Message, "{nick}", event.mm.BotUser.Username, -1)
 	response.Message = strings.Replace(response.Message, "{0}", event.body, -1)
 
 	return response, nil

--- a/internal/commands/praise.go
+++ b/internal/commands/praise.go
@@ -3,11 +3,12 @@ package commands
 import (
 	"fmt"
 	"math/rand"
-	"time"
 	"strings"
+	"time"
 )
 
 func (bc BotCommand) Praise(event BotCommand) (response Response, err error) {
+	praises := event.settings.GetPraises()
 	response.Type = "post"
 	var index int
 
@@ -15,12 +16,12 @@ func (bc BotCommand) Praise(event BotCommand) (response Response, err error) {
 		response.Type = "post"
 		response.Message = "You must tell me who to insult"
 	}
-	arraySize := len(event.mm.Settings.Praises)
+	arraySize := len(praises)
 
 	rand := rand.New(rand.NewSource(time.Now().UnixNano()))
 	index = rand.Intn(arraySize)
-	response.Message = fmt.Sprintf(`%s`, event.mm.Settings.Praises[index])
-	response.Message = strings.Replace(response.Message, "{nick}", event.mm.Settings.Nick, -1)
+	response.Message = fmt.Sprintf(`%s`, praises[index])
+	response.Message = strings.Replace(response.Message, "{nick}", event.mm.BotUser.Username, -1)
 	response.Message = strings.Replace(response.Message, "{0}", event.body, -1)
 
 	return response, nil

--- a/internal/commands/quote.go
+++ b/internal/commands/quote.go
@@ -3,17 +3,18 @@ package commands
 import (
 	"fmt"
 	"math/rand"
-	"time"
 	"strconv"
 	"strings"
+	"time"
 )
 
 func (bc BotCommand) Quote(event BotCommand) (response Response, err error) {
+	quotes := event.settings.GetQuotes()
 	response.Type = "post"
 	var index int
 
 	if event.body == "" {
-		arraySize := len(event.mm.Settings.Quotes)
+		arraySize := len(quotes)
 
 		rand := rand.New(rand.NewSource(time.Now().UnixNano()))
 		index = rand.Intn(arraySize)
@@ -23,8 +24,8 @@ func (bc BotCommand) Quote(event BotCommand) (response Response, err error) {
 			return response, err
 		}
 	}
-	response.Message = fmt.Sprintf(`%s`, event.mm.Settings.Quotes[index])
-	response.Message = strings.Replace(response.Message, "{nick}", event.mm.Settings.Nick, -1)
+	response.Message = fmt.Sprintf(`%s`, quotes[index])
+	response.Message = strings.Replace(response.Message, "{nick}", event.mm.BotUser.Username, -1)
 	response.Message = strings.Replace(response.Message, "{0}", event.sender, -1)
 
 	return response, nil

--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -27,9 +27,8 @@ func NewHandler(mm *mmclient.MMClient) (*Handler, error) {
 }
 
 func (h *Handler) HandleWebSocketResponse(event *model.WebSocketEvent) {
-	// We don't want these fellas blocking the bot from picking up new events
-	go h.HandleMsgFromDebuggingChannel(event)
-	go h.HandleMsgFromChannel(event)
+	h.HandleMsgFromDebuggingChannel(event)
+	h.HandleMsgFromChannel(event)
 }
 
 func (h *Handler) HandleMsgFromChannel(event *model.WebSocketEvent) {

--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -27,8 +27,9 @@ func NewHandler(mm *mmclient.MMClient) (*Handler, error) {
 }
 
 func (h *Handler) HandleWebSocketResponse(event *model.WebSocketEvent) {
-	h.HandleMsgFromDebuggingChannel(event)
-	h.HandleMsgFromChannel(event)
+	// We don't want these fellas blocking the bot from picking up new events
+	go h.HandleMsgFromDebuggingChannel(event)
+	go h.HandleMsgFromChannel(event)
 }
 
 func (h *Handler) HandleMsgFromChannel(event *model.WebSocketEvent) {

--- a/internal/mmclient/config.go
+++ b/internal/mmclient/config.go
@@ -3,10 +3,6 @@ package mmclient
 import (
 	"fmt"
 	"os"
-	"net/http"
-	"time"
-	"encoding/json"
-	"io/ioutil"
 
 	"github.com/tkanos/gonfig"
 )
@@ -30,27 +26,6 @@ type Config struct {
 	} `yaml:"bot"`
 }
 
-type ChannelList struct {
-	id	int
-	name	string
-}
-
-type Settings struct {
-	Server		string		`json: "@server"`
-	Password	string		`json: "@password"`
-	Port		int		`json: "@port"`
-	Secure		int		`json: "@secure"`
-	server_validate string		`json: "@server_validate"`
-	User		string		`json: "@user"`
-	Nick		string		`json: "@nick"`
-	Channels	[]ChannelList	`json: "@channels"`
-	Admins		[]string	`json: "@admins"`
-	Command_start	string		`json: "@command_start"`
-	Insults		[]string	`json: "@insults"`
-	Quotes		[]string	`json: "@quotes"`
-	Praises		[]string	`json: "@praises"`
-}
-
 func GetConfig(params ...string) (*Config, error) {
 	cfg := Config{}
 
@@ -67,24 +42,4 @@ func GetConfig(params ...string) (*Config, error) {
 	err := gonfig.GetConf(fileName, &cfg)
 
 	return &cfg, err
-}
-
-func GetSettings(cfg *Config, target *Settings) (error) {
-	httpClient := &http.Client{Timeout: 10 * time.Second}
-
-	r, err := httpClient.Get(cfg.Bot.SETTINGS_URL)
-
-	if err != nil {
-		return err
-	}
-	defer r.Body.Close()
-
-	data, err := ioutil.ReadAll(r.Body)
-	if err != nil {
-		return err
-	}
-
-	err = json.Unmarshal(data, &target)
-
-	return err
 }

--- a/internal/mmclient/mmclient.go
+++ b/internal/mmclient/mmclient.go
@@ -16,8 +16,8 @@ type MMClient struct {
 	BotTeam          *model.Team
 	DebuggingChannel *model.Channel
 	Server           Server
+	SettingsUrl      string
 	cfg              *Config
-	Settings	 *Settings
 }
 
 type Server struct {
@@ -36,13 +36,8 @@ func NewMMClient() (client *MMClient, err error) {
 		return client, err
 	}
 
-	client.Settings = &Settings{}
-	err = GetSettings(client.cfg, client.Settings)
-	if err != nil {
-		return client, err
-	}
-
 	client.Server = client.cfg.Server
+	client.SettingsUrl = client.cfg.Bot.SETTINGS_URL
 	conn := client.Server.PROTOCOL + client.Server.HOST
 	client.Client = model.NewAPIv4Client(conn)
 

--- a/internal/settings/settings.go
+++ b/internal/settings/settings.go
@@ -16,10 +16,10 @@ type (
 	}
 
 	CommandSettings struct {
-		CommandTrigger string   `json:"@command_start"`
-		Insults        []string `json:"@insults"`
-		Quotes         []string `json:"@quotes"`
-		Praises        []string `json:"@praises"`
+		CommandTrigger string   `json:"command_start"`
+		Insults        []string `json:"insults"`
+		Quotes         []string `json:"quotes"`
+		Praises        []string `json:"praises"`
 	}
 )
 

--- a/internal/settings/settings.go
+++ b/internal/settings/settings.go
@@ -1,0 +1,89 @@
+package settings
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"sync"
+	"time"
+)
+
+type (
+	Settings struct {
+		mu          sync.RWMutex
+		settingsUrl string
+		settings    CommandSettings
+	}
+
+	CommandSettings struct {
+		CommandTrigger string   `json:"@command_start"`
+		Insults        []string `json:"@insults"`
+		Quotes         []string `json:"@quotes"`
+		Praises        []string `json:"@praises"`
+	}
+)
+
+func NewSettings(settingsUrl string) (*Settings, error) {
+	sc := &Settings{
+		settingsUrl: settingsUrl,
+	}
+
+	err := sc.LoadSettings()
+
+	return sc, err
+}
+
+func (c *Settings) LoadSettings() error {
+	var s CommandSettings
+	hc := &http.Client{Timeout: 10 * time.Second}
+
+	r, err := hc.Get(c.settingsUrl)
+	if err != nil {
+		return err
+	}
+	defer r.Body.Close()
+
+	b, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		return err
+	}
+
+	err = json.Unmarshal(b, &s)
+	if err != nil {
+		return err
+	}
+
+	c.mu.Lock()
+	c.settings = s
+	c.mu.Unlock()
+
+	return nil
+}
+
+func (c *Settings) GetCommandTrigger() string {
+	c.mu.RLock()
+	commandTrigger := c.settings.CommandTrigger
+	c.mu.RUnlock()
+	return commandTrigger
+}
+
+func (c *Settings) GetInsults() []string {
+	c.mu.RLock()
+	insults := c.settings.Insults
+	c.mu.RUnlock()
+	return insults
+}
+
+func (c *Settings) GetQuotes() []string {
+	c.mu.RLock()
+	quotes := c.settings.Quotes
+	c.mu.RUnlock()
+	return quotes
+}
+
+func (c *Settings) GetPraises() []string {
+	c.mu.RLock()
+	praises := c.settings.Praises
+	c.mu.RUnlock()
+	return praises
+}

--- a/main.go
+++ b/main.go
@@ -34,7 +34,8 @@ func main() {
 		ws.Listen()
 
 		for resp := range ws.EventChannel {
-			handler.HandleWebSocketResponse(resp)
+			// We don't want this fella blocking the bot from picking up new events
+			go handler.HandleWebSocketResponse(resp)
 		}
 	}
 }

--- a/main.go
+++ b/main.go
@@ -17,7 +17,10 @@ func main() {
 		log.Fatalln(err.Error())
 	}
 
-	handler := handler.NewHandler(mm)
+	handler, err := handler.NewHandler(mm)
+	if err != nil {
+		log.Fatalln(err.Error())
+	}
 
 	// Lets start listening to some channels via the websocket!
 	for {


### PR DESCRIPTION
## Summary
Makes the bot command settings pulled from the server its own package and separates it from the mmclient configuration
stored in the yaml file locally. The rationale being that the file contains secure settings needed to communicate with Mattermost and shouldn't be passed around, but the command settings need to be.

Settings are instantiated as part of the handler package in `main()` so it can be passed into anything for future use. Settings are cached and use methods to retrieve and set values.

Added a groutine to the call to `handler.HandleWebSocketResponse()` in main so the bot doesn't block when a new event comes in
