### PR TITLE
Add redis cache

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,9 +1,25 @@
 version: "3.9"
+
+volumes:
+  redis:
+
 services:
   test_mm:
     image: mattermost/mattermost-preview
     container_name: test_mm
-    ports: 
+    ports:
     - "8065:8065"
     environment:
       MM_SERVICESETTINGS_ENABLELOCALMODE: "true"
+
+  redis:
+    container_name: redis
+    image: "redis:6.0.9-alpine"
+    command: redis-server --requirepass password
+    restart: always
+    ports:
+      - 6379:6379
+    volumes:
+      - redis:/data
+
+

--- a/go.mod
+++ b/go.mod
@@ -3,13 +3,15 @@ module github.com/pyrousnet/mattermost-golang-bot
 go 1.19
 
 require (
+	github.com/go-redis/redis/v8 v8.11.5
 	github.com/mattermost/mattermost-server/v5 v5.39.3
 	github.com/tkanos/gonfig v0.0.0-20210106201359-53e13348de2f
-	golang.org/x/exp v0.0.0-20220916125017-b168a2c6b86b
 )
 
 require (
 	github.com/blang/semver v3.5.1+incompatible // indirect
+	github.com/cespare/xxhash/v2 v2.1.2 // indirect
+	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	github.com/dustin/go-humanize v1.0.0 // indirect
 	github.com/dyatlov/go-opengraph v0.0.0-20210112100619-dae8665a5b09 // indirect
 	github.com/francoispqt/gojay v1.2.13 // indirect

--- a/go.sum
+++ b/go.sum
@@ -136,6 +136,8 @@ github.com/census-instrumentation/opencensus-proto v0.2.0/go.mod h1:f6KPmirojxKA
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
+github.com/cespare/xxhash/v2 v2.1.2 h1:YRXhKfTDauu4ajMg1TPgFO5jnlC2HCbmLXMcTG5cbYE=
+github.com/cespare/xxhash/v2 v2.1.2/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
@@ -182,6 +184,7 @@ github.com/dgraph-io/badger v1.6.0/go.mod h1:zwt7syl517jmP8s94KqSxTlM6IMsdhYy6ps
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/dgoogauth v0.0.0-20190221195224-5a805980a5f3/go.mod h1:hEfFauPHz7+NnjR/yHJGhrKo1Za+zStgwUETx3yzqgY=
 github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2/go.mod h1:SqUrOPUnsFjfmXRMNPybcSiG0BgUW2AuFH8PAnS2iTw=
+github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/dhui/dktest v0.3.3/go.mod h1:EML9sP4sqJELHn4jV7B0TY8oF6077nk83/tz7M56jcQ=
@@ -227,6 +230,7 @@ github.com/fortytw2/leaktest v1.3.0/go.mod h1:jDsjWgpAGjm2CA7WthBh/CdZYEPF31XHqu
 github.com/francoispqt/gojay v1.2.13 h1:d2m3sFjloqoIUQU3TsHBgj6qg/BVGlTBeHDUmyJnXKk=
 github.com/francoispqt/gojay v1.2.13/go.mod h1:ehT5mTG4ua4581f1++1WLG0vPdaA9HaiDsoyrBGkyDY=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
+github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/fsouza/fake-gcs-server v1.17.0/go.mod h1:D1rTE4YCyHFNa99oyJJ5HyclvN/0uQR+pM/VdlL83bw=
 github.com/garyburd/redigo v1.6.0/go.mod h1:NR3MbYisc3/PwhQ00EMzDiPmrwpPxAn5GI05/YaO1SY=
@@ -257,6 +261,8 @@ github.com/go-logfmt/logfmt v0.5.0/go.mod h1:wCYkCAKZfumFQihp8CzCvQ3paCTfi41vtzG
 github.com/go-martini/martini v0.0.0-20170121215854-22fa46961aab/go.mod h1:/P9AEU963A2AYjv4d1V5eVL1CQbEJq6aCNHDDjibzu8=
 github.com/go-redis/redis/v8 v8.0.0/go.mod h1:isLoQT/NFSP7V67lyvM9GmdvLdyZ7pEhsXvvyQtnQTo=
 github.com/go-redis/redis/v8 v8.10.0/go.mod h1:vXLTvigok0VtUX0znvbcEW1SOt4OA9CU1ZfnOtKOaiM=
+github.com/go-redis/redis/v8 v8.11.5 h1:AcZZR7igkdvfVmQTPnu9WE37LRrO/YrBH5zWyjDC0oI=
+github.com/go-redis/redis/v8 v8.11.5/go.mod h1:gREzHqY1hg6oD9ngVRbLStwAWKhA0FEgq8Jd4h5lpwo=
 github.com/go-resty/resty/v2 v2.0.0/go.mod h1:dZGr0i9PLlaaTD4H/hoZIDjQ+r6xq8mgbRzHZf7f2J8=
 github.com/go-resty/resty/v2 v2.3.0/go.mod h1:UpN9CgLZNsv4e9XG50UU8xdI0F43UQ4HmxLBDwaroHU=
 github.com/go-resty/resty/v2 v2.6.0/go.mod h1:PwvJS6hvaPkjtjNg9ph+VrSD92bi5Zq73w/BIH7cC3Q=
@@ -627,6 +633,7 @@ github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646/go.mod h1:jpp1/29i3P1S
 github.com/ngdinhtoan/glide-cleanup v0.2.0/go.mod h1:UQzsmiDOb8YV3nOsCxK/c9zPpCZVNoHScRE3EO9pVMM=
 github.com/nwaples/rardecode v1.1.0/go.mod h1:5DzqNKiOdpKKBH87u8VlvAnPZMXcGRhxWkRpHbbfGS0=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
+github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
 github.com/oklog/run v1.1.0/go.mod h1:sVPdnTZT1zYwAJeCMu2Th4T21pA3FPOQRfWjQlk7DVU=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
@@ -642,12 +649,14 @@ github.com/onsi/ginkgo v1.12.1/go.mod h1:zj2OWP4+oCPe1qIXoGWkgMRwljMUYCdkwsT2108
 github.com/onsi/ginkgo v1.13.0/go.mod h1:+REjRxOmWfHCjfv9TTWB1jD1Frx4XydAD3zm1lskyM0=
 github.com/onsi/ginkgo v1.14.1/go.mod h1:iSB4RoI2tjJc9BBv4NKIKWKya62Rps+oPG/Lv9klQyY=
 github.com/onsi/ginkgo v1.15.0/go.mod h1:hF8qUzuuC8DJGygJH3726JnCZX4MYbRB8yFfISqnKUg=
+github.com/onsi/ginkgo v1.16.5 h1:8xi0RTUf59SOSfEtZMvwTvXYMzG4gV23XVHOZiXNtnE=
 github.com/onsi/gomega v1.4.3/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7JYyY=
 github.com/onsi/gomega v1.9.0/go.mod h1:Ho0h+IUsWyvy1OpqCwxlQ/21gkhVunqlU8fDGcoTdcA=
 github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
 github.com/onsi/gomega v1.10.2/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
 github.com/onsi/gomega v1.10.5/go.mod h1:gza4q3jKQJijlu05nKWRCW/GavJumGt8aNRxWg7mt48=
+github.com/onsi/gomega v1.18.1 h1:M1GfJqGRrBrrGGsbxzV5dqM2U2ApXefZCQpkukxYRLE=
 github.com/oov/psd v0.0.0-20210618170533-9fb823ddb631/go.mod h1:GHI1bnmAcbp96z6LNfBJvtrjxhaXGkbsk967utPlvL8=
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.0.1/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zMzWCbyJoFRP3s7yZA0=
@@ -959,8 +968,6 @@ golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a/go.mod h1:2RIsYlXP63K8oxa1u0
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
 golang.org/x/exp v0.0.0-20200908183739-ae8ad444f925/go.mod h1:1phAWC201xIgDyaFpmDeZkgf70Q4Pd/CNqfRtVPtxNw=
-golang.org/x/exp v0.0.0-20220916125017-b168a2c6b86b h1:SCE/18RnFsLrjydh/R/s5EVvHoZprqEQUuoxK8q2Pc4=
-golang.org/x/exp v0.0.0-20220916125017-b168a2c6b86b/go.mod h1:cyybsKvd6eL0RnXn6p/Grxp8F5bW7iYuBgsNCOHpMYE=
 golang.org/x/image v0.0.0-20180708004352-c73c2afc3b81/go.mod h1:ux5Hcp/YLpHSI86hEcLt0YII63i6oz57MZXIpbrjZUs=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190321063152-3fc05d484e9f/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
@@ -1350,6 +1357,7 @@ gopkg.in/natefinch/lumberjack.v2 v2.0.0 h1:1Lc07Kr7qY4U2YPouBjpCLxpiyxIVoxqXgkXL
 gopkg.in/natefinch/lumberjack.v2 v2.0.0/go.mod h1:l0ndWWf7gzL7RNwBG7wST/UCcT4T24xpD6X8LsfU/+k=
 gopkg.in/olivere/elastic.v6 v6.2.35/go.mod h1:2cTT8Z+/LcArSWpCgvZqBgt3VOqXiy7v00w12Lz8bd4=
 gopkg.in/resty.v1 v1.12.0/go.mod h1:mDo4pnntr5jdWRML875a/NmxYqAlA73dVijT2AXvQQo=
+gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 h1:uRGJdciOHaEIrze2W8Q3AKkepLTh2hOroT7a+7czfdQ=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
 gopkg.in/yaml.v2 v2.0.0-20170812160011-eb3733d160e7/go.mod h1:JAlM8MvJe8wmxCU4Bli9HhUf9+ttbYbLASfIpnQbh74=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -1,11 +1,7 @@
 package cache
 
 import (
-	"context"
-	"fmt"
 	"net/url"
-
-	"github.com/go-redis/redis/v8"
 )
 
 type Cache interface {
@@ -17,69 +13,13 @@ type Cache interface {
 	CleanAll()
 }
 
-type RedisCache struct {
-	conn *redis.Client
-	ctx  context.Context
-}
-
-var cfg struct {
-	ConnectionString string
-}
-
 func GetCachingMechanism(connStr string) Cache {
 	uri, _ := url.Parse(connStr)
-	password, _ := uri.User.Password()
 
-	cch := &RedisCache{
-		conn: redis.NewClient(&redis.Options{
-			Addr:     fmt.Sprintf("%s:%s", uri.Hostname(), uri.Port()),
-			Username: uri.User.Username(),
-			Password: password,
-		}),
+	switch uri.Scheme {
+	case "redis":
+		return GetRedisCache(connStr)
+	default:
+		return GetLocalCache()
 	}
-
-	cch.ctx = context.Background()
-
-	return cch
-}
-
-func (rc *RedisCache) Put(key string, value interface{}) {
-	if err := rc.conn.Set(rc.ctx, key, value, 0); err != nil {
-		fmt.Println(err)
-	}
-}
-
-func (rc *RedisCache) PutAll(entries map[string]interface{}) {
-	for k, v := range entries {
-		rc.Put(k, v)
-	}
-}
-
-func (rc *RedisCache) Get(key string) interface{} {
-	value, err := rc.conn.Get(rc.ctx, key).Result()
-	if err != nil {
-		fmt.Println(err)
-		return ""
-	}
-	return value
-}
-
-func (rc *RedisCache) GetAll(keys []string) map[string]interface{} {
-	entries := make(map[string]interface{})
-	for _, k := range keys {
-		entries[k] = rc.Get(k)
-	}
-
-	return entries
-}
-
-func (rc *RedisCache) Clean(key string) {
-	if err := rc.conn.Del(rc.ctx, key); err != nil {
-		fmt.Println(err)
-	}
-}
-
-// CleanAll cleans the entire cache.
-func (rc *RedisCache) CleanAll() {
-	rc.conn.FlushDB(rc.ctx)
 }

--- a/internal/cache/local.go
+++ b/internal/cache/local.go
@@ -1,0 +1,56 @@
+package cache
+
+import (
+	"sync"
+)
+
+type LocalCache struct {
+	mu   sync.RWMutex
+	data map[string]interface{}
+}
+
+func GetLocalCache() *LocalCache {
+	lc := &LocalCache{}
+
+	return lc
+}
+
+func (c *LocalCache) Put(key string, value interface{}) {
+	c.mu.Lock()
+	c.data[key] = value
+	c.mu.Unlock()
+}
+
+func (c *LocalCache) PutAll(entries map[string]interface{}) {
+	for k, v := range entries {
+		c.Put(k, v)
+	}
+}
+
+func (c *LocalCache) Get(key string) interface{} {
+	c.mu.RLock()
+	data, _ := c.data[key]
+	c.mu.RUnlock()
+	return data
+}
+
+func (c *LocalCache) GetAll(keys []string) map[string]interface{} {
+	entries := make(map[string]interface{})
+	for _, k := range keys {
+		entries[k] = c.Get(k)
+	}
+
+	return entries
+}
+
+func (c *LocalCache) Clean(key string) {
+	c.mu.Lock()
+	delete(c.data, key)
+	c.mu.Unlock()
+}
+
+func (c *LocalCache) CleanAll() {
+	c.mu.Lock()
+	c.data = make(map[string]interface{})
+	c.mu.Unlock()
+}

--- a/internal/cache/redis.go
+++ b/internal/cache/redis.go
@@ -1,0 +1,72 @@
+package cache
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+
+	"github.com/go-redis/redis/v8"
+)
+
+type RedisCache struct {
+	conn *redis.Client
+	ctx  context.Context
+}
+
+func GetRedisCache(connStr string) *RedisCache {
+	uri, _ := url.Parse(connStr)
+	password, _ := uri.User.Password()
+
+	cch := &RedisCache{
+		conn: redis.NewClient(&redis.Options{
+			Addr:     fmt.Sprintf("%s:%s", uri.Hostname(), uri.Port()),
+			Username: uri.User.Username(),
+			Password: password,
+		}),
+	}
+
+	cch.ctx = context.Background()
+
+	return cch
+}
+
+func (rc *RedisCache) Put(key string, value interface{}) {
+	if err := rc.conn.Set(rc.ctx, key, value, 0); err != nil {
+		fmt.Println(err)
+	}
+}
+
+func (rc *RedisCache) PutAll(entries map[string]interface{}) {
+	for k, v := range entries {
+		rc.Put(k, v)
+	}
+}
+
+func (rc *RedisCache) Get(key string) interface{} {
+	value, err := rc.conn.Get(rc.ctx, key).Result()
+	if err != nil {
+		fmt.Println(err)
+		return ""
+	}
+	return value
+}
+
+func (rc *RedisCache) GetAll(keys []string) map[string]interface{} {
+	entries := make(map[string]interface{})
+	for _, k := range keys {
+		entries[k] = rc.Get(k)
+	}
+
+	return entries
+}
+
+func (rc *RedisCache) Clean(key string) {
+	if err := rc.conn.Del(rc.ctx, key); err != nil {
+		fmt.Println(err)
+	}
+}
+
+// CleanAll cleans the entire cache.
+func (rc *RedisCache) CleanAll() {
+	rc.conn.FlushDB(rc.ctx)
+}

--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -6,6 +6,7 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/pyrousnet/mattermost-golang-bot/internal/cache"
 	"github.com/pyrousnet/mattermost-golang-bot/internal/commands"
 	"github.com/pyrousnet/mattermost-golang-bot/internal/mmclient"
 	"github.com/pyrousnet/mattermost-golang-bot/internal/settings"
@@ -14,16 +15,18 @@ import (
 )
 
 type Handler struct {
+	Cache    cache.Cache
 	Settings *settings.Settings
 	mm       *mmclient.MMClient
 }
 
-func NewHandler(mm *mmclient.MMClient) (*Handler, error) {
+func NewHandler(mm *mmclient.MMClient, redis cache.Cache) (*Handler, error) {
 	settings, err := settings.NewSettings(mm.SettingsUrl)
 
 	return &Handler{
 		Settings: settings,
 		mm:       mm,
+		Cache:    redis,
 	}, err
 }
 

--- a/internal/mmclient/config.go
+++ b/internal/mmclient/config.go
@@ -2,7 +2,6 @@ package mmclient
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/tkanos/gonfig"
 )
@@ -26,14 +25,8 @@ type Config struct {
 	} `yaml:"bot"`
 }
 
-func GetConfig(params ...string) (*Config, error) {
+func GetConfig(env string) (*Config, error) {
 	cfg := Config{}
-
-	//TODO: Set default env to prod
-	env := os.Getenv("ENV")
-	if env == "" {
-		env = "dev"
-	}
 
 	// This here is only going to work so long as the bot is started in the main working directory.
 	// We might want to set this to pull from some config directory in $GOROOT

--- a/internal/mmclient/mmclient.go
+++ b/internal/mmclient/mmclient.go
@@ -28,10 +28,10 @@ type Server struct {
 
 // Documentation for the Go driver can be found
 // at https://godoc.org/github.com/mattermost/platform/model#Client
-func NewMMClient() (client *MMClient, err error) {
+func NewMMClient(env string) (client *MMClient, err error) {
 	client = &MMClient{}
 
-	client.cfg, err = GetConfig()
+	client.cfg, err = GetConfig(env)
 	if err != nil {
 		return client, err
 	}

--- a/internal/mmclient/mmclient.go
+++ b/internal/mmclient/mmclient.go
@@ -7,6 +7,7 @@ import (
 	"os/signal"
 
 	"github.com/mattermost/mattermost-server/v5/model"
+	"github.com/pyrousnet/mattermost-golang-bot/internal/settings"
 )
 
 type MMClient struct {
@@ -17,7 +18,7 @@ type MMClient struct {
 	DebuggingChannel *model.Channel
 	Server           Server
 	SettingsUrl      string
-	cfg              *Config
+	cfg              *settings.Config
 }
 
 type Server struct {
@@ -28,14 +29,10 @@ type Server struct {
 
 // Documentation for the Go driver can be found
 // at https://godoc.org/github.com/mattermost/platform/model#Client
-func NewMMClient(env string) (client *MMClient, err error) {
+func NewMMClient(cfg *settings.Config) (client *MMClient, err error) {
 	client = &MMClient{}
 
-	client.cfg, err = GetConfig(env)
-	if err != nil {
-		return client, err
-	}
-
+	client.cfg = cfg
 	client.Server = client.cfg.Server
 	client.SettingsUrl = client.cfg.Bot.SETTINGS_URL
 	conn := client.Server.PROTOCOL + client.Server.HOST

--- a/internal/settings/config.go
+++ b/internal/settings/config.go
@@ -1,4 +1,4 @@
-package mmclient
+package settings
 
 import (
 	"fmt"
@@ -23,8 +23,12 @@ type Config struct {
 		LOG_NAME      string `yaml:"log_name"`
 		SETTINGS_URL  string `yaml:"settings_url"`
 	} `yaml:"bot"`
+	Cache struct {
+		CONN_STR string `yaml:"connection_string"`
+	} `yaml:"cache"`
 }
 
+// GetConfig reads the bot configuration file and loads into a Config struct
 func GetConfig(env string) (*Config, error) {
 	cfg := Config{}
 

--- a/main.go
+++ b/main.go
@@ -6,13 +6,20 @@ package main
 import (
 	"fmt"
 	"log"
+	"os"
 
 	"github.com/pyrousnet/mattermost-golang-bot/internal/handler"
 	"github.com/pyrousnet/mattermost-golang-bot/internal/mmclient"
 )
 
 func main() {
-	mm, err := mmclient.NewMMClient()
+	//TODO: Set default env to prod
+	env := os.Getenv("ENV")
+	if env == "" {
+		env = "dev"
+	}
+
+	mm, err := mmclient.NewMMClient(env)
 	if err != nil {
 		log.Fatalln(err.Error())
 	}

--- a/main.go
+++ b/main.go
@@ -8,8 +8,10 @@ import (
 	"log"
 	"os"
 
+	"github.com/pyrousnet/mattermost-golang-bot/internal/cache"
 	"github.com/pyrousnet/mattermost-golang-bot/internal/handler"
 	"github.com/pyrousnet/mattermost-golang-bot/internal/mmclient"
+	"github.com/pyrousnet/mattermost-golang-bot/internal/settings"
 )
 
 func main() {
@@ -19,19 +21,26 @@ func main() {
 		env = "dev"
 	}
 
-	mm, err := mmclient.NewMMClient(env)
+	cfg, err := settings.GetConfig(env)
 	if err != nil {
 		log.Fatalln(err.Error())
 	}
 
-	handler, err := handler.NewHandler(mm)
+	mmClient, err := mmclient.NewMMClient(cfg)
+	if err != nil {
+		log.Fatalln(err.Error())
+	}
+
+	redis := cache.GetCachingMechanism(cfg.Cache.CONN_STR)
+
+	handler, err := handler.NewHandler(mmClient, redis)
 	if err != nil {
 		log.Fatalln(err.Error())
 	}
 
 	// Lets start listening to some channels via the websocket!
 	for {
-		ws, err := mm.NewWebSocketClient()
+		ws, err := mmClient.NewWebSocketClient()
 		if err != nil {
 			log.Fatalf(err.Error())
 		}

--- a/main.go
+++ b/main.go
@@ -31,9 +31,9 @@ func main() {
 		log.Fatalln(err.Error())
 	}
 
-	redis := cache.GetCachingMechanism(cfg.Cache.CONN_STR)
+	botCache := cache.GetCachingMechanism(cfg.Cache.CONN_STR)
 
-	handler, err := handler.NewHandler(mmClient, redis)
+	handler, err := handler.NewHandler(mmClient, botCache)
 	if err != nil {
 		log.Fatalln(err.Error())
 	}

--- a/sample-config.yml
+++ b/sample-config.yml
@@ -14,3 +14,6 @@ bot:
   team_name: "teamname"
   log_channel: "test-channel"
   settings_url: "https://yourdomain.com/config"
+# Cache configurations
+cache:
+  connection_string: "redis://:password@host:port"


### PR DESCRIPTION
This makes the cache interface use Redis under the hood. It's now available in the handler as well.

You'll need to make sure you have Redis running locally now before you start the bot. I updated `docker-compose.yml` to include Redis for dev. You can start it up by running `docker compose up redis`.

Add the following to the bottom of your `dev_config.yml`:
```
# Cache configurations
cache:
  connection_string: "redis://:password@127.0.0.1:6379"
```